### PR TITLE
GetAverageItemLevel fix

### DIFF
--- a/ElvUI_Enhanced/Modules/Blizzard/CharacterFrame.lua
+++ b/ElvUI_Enhanced/Modules/Blizzard/CharacterFrame.lua
@@ -760,7 +760,7 @@ end
 ]]
 
 local function GetAverageItemLevel()
-	local items = 16
+	local items = 0
 	local ilvl = 0
 	local colorCount, sumR, sumG, sumB = 0, 0, 0, 0
 
@@ -771,17 +771,15 @@ local function GetAverageItemLevel()
 			if itemLink then
 				local _, _, quality, itemLevel, _, _, _, _, itemEquipLoc = GetItemInfo(itemLink)
 
-				if itemLevel then
+				if itemLevel and itemLevel > 0 then
 					ilvl = ilvl + itemLevel
+					items = items + 1
 
 					colorCount = colorCount + 1
 					sumR = sumR + qualityColors[quality][1]
 					sumG = sumG + qualityColors[quality][2]
 					sumB = sumB + qualityColors[quality][3]
 
-					if slotID == INVSLOT_MAINHAND and (itemEquipLoc ~= "INVTYPE_2HWEAPON" or titanGrip) then
-						items = 17
-					end
 				end
 			end
 		end


### PR DESCRIPTION
1. Should not simply divide the total level of items by 16, as a player may not be wearing all items, but, for example, only 2
2. Can't just assume that if a player has a one-handed weapon, it means there is necessarily a shield or weapon in his left hand