### PR TITLE
Fix SkadaRev report issue

### DIFF
--- a/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
+++ b/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
@@ -46,7 +46,7 @@ local spamFirstLines = {
 local spamNextLines = {
 	"^(%d+)%. (.*)$",	-- Recount, Skada
 	"^ (%d+). (.*)$",	-- Skada
---	"^(.*)   (.*)$",	-- Additional Skada
+	"^(.*)[%s](.*)$", -- Additional Skada
 	"^.*%%%)$",			-- Skada player details
 	"^(%d+). (.*):(.*)(%d+)(.*)(%d+)%%(.*)%((%d+)%)$", -- TinyDPS
 }

--- a/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
+++ b/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
@@ -46,7 +46,7 @@ local spamFirstLines = {
 local spamNextLines = {
 	"^(%d+)%. (.*)$",	-- Recount, Skada
 	"^ (%d+). (.*)$",	-- Skada
-	"^(.*)[%s]*(.*)$",	-- Additional Skada
+	"^(.*) (.*)$",	-- Additional Skada
 	"^.*%%%)$",			-- Skada player details
 	"^(%d+). (.*):(.*)(%d+)(.*)(%d+)%%(.*)%((%d+)%)$", -- TinyDPS
 }

--- a/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
+++ b/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
@@ -46,7 +46,8 @@ local spamFirstLines = {
 local spamNextLines = {
 	"^(%d+)%. (.*)$",	-- Recount, Skada
 	"^ (%d+). (.*)$",	-- Skada
-	"^(.*): (.*)$", -- Additional Skada
+	"^(.*): (.*)$", 	-- Additional Skada details
+--	"^(.*)   (.*)$",	-- Additional Skada
 	"^.*%%%)$",			-- Skada player details
 	"^(%d+). (.*):(.*)(%d+)(.*)(%d+)%%(.*)%((%d+)%)$", -- TinyDPS
 }

--- a/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
+++ b/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
@@ -46,7 +46,7 @@ local spamFirstLines = {
 local spamNextLines = {
 	"^(%d+)%. (.*)$",	-- Recount, Skada
 	"^ (%d+). (.*)$",	-- Skada
-	"^(.*) (.*)$",	-- Additional Skada
+	"^(.*): (.*)$", -- Additional Skada
 	"^.*%%%)$",			-- Skada player details
 	"^(%d+). (.*):(.*)(%d+)(.*)(%d+)%%(.*)%((%d+)%)$", -- TinyDPS
 }

--- a/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
+++ b/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
@@ -46,7 +46,7 @@ local spamFirstLines = {
 local spamNextLines = {
 	"^(%d+)%. (.*)$",	-- Recount, Skada
 	"^ (%d+). (.*)$",	-- Skada
-	"^(.*)[%s](.*)$", -- Additional Skada
+	"^(.*)[%s](.*)$",	-- Additional Skada
 	"^.*%%%)$",			-- Skada player details
 	"^(%d+). (.*):(.*)(%d+)(.*)(%d+)%%(.*)%((%d+)%)$", -- TinyDPS
 }

--- a/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
+++ b/ElvUI_Enhanced/Modules/Chat/DPSLinks.lua
@@ -46,7 +46,7 @@ local spamFirstLines = {
 local spamNextLines = {
 	"^(%d+)%. (.*)$",	-- Recount, Skada
 	"^ (%d+). (.*)$",	-- Skada
-	"^(.*)[%s](.*)$",	-- Additional Skada
+	"^(.*)[%s]*(.*)$",	-- Additional Skada
 	"^.*%%%)$",			-- Skada player details
 	"^(%d+). (.*):(.*)(%d+)(.*)(%d+)%%(.*)%((%d+)%)$", -- TinyDPS
 }


### PR DESCRIPTION
We noticed that Filter DPSLinks only filters mode main bars (_players list_), whenever you click on a player to list details and try to report, the first line is caught, next lines are not.
After testing it on Warmane, it turned out that spaces were being stripped, from 2 or 3 spaces down to one and that causes the module to fail.
Changing the line and allowing any amount of spaces for next lines fixed the problem.