### PR TITLE
Fix NPC nameplates issue after respawning

### DIFF
--- a/ElvUI_Enhanced/Modules/Nameplates/Nameplates.lua
+++ b/ElvUI_Enhanced/Modules/Nameplates/Nameplates.lua
@@ -80,7 +80,13 @@ function ENP:UPDATE_MOUSEOVER_UNIT()
 		local description = _G["Enhanced_ScanningTooltipTextLeft2"]:GetText()
 		if not description then return end
 
-		if match(description, UNIT_LEVEL_TEMPLATE) then return end
+		if match(description, UNIT_LEVEL_TEMPLATE) then 
+			if EnhancedDB.UnitTitle[name] then
+				EnhancedDB.UnitTitle[name] = nil
+				UpdateNameplateByName(name)
+			end
+			return
+		end
 
 		name = gsub(gsub((name), "|c........", "" ), "|r", "")
 		if name ~= UnitName("mouseover") then return end


### PR DESCRIPTION
Fix a bug where some NPCs that do not have a title (description) when they are alive remain "N-level creature corpse" after respawning

NPC title:
**"Corpse of a level 75 creature"**
!["Труп существа 75-го уровня"](http://egammi.com/images/2021/11/02/SyYE.md.png)