### PR TITLE
Fix AnimatedAchievementsBars.lua error

### DIFF
--- a/ElvUI_Enhanced/Modules/Blizzard/AnimatedAchievementsBars.lua
+++ b/ElvUI_Enhanced/Modules/Blizzard/AnimatedAchievementsBars.lua
@@ -76,14 +76,17 @@ S:AddCallbackForAddon("Blizzard_AchievementUI", "Enhanced_AchievementUI", functi
 	end)
 
 	hooksecurefunc("AchievementFrameComparison_UpdateStatusBars", function(id)
+		local numAchievements, numCompleted
 		if id == "summary" then
-			id = -1
+			numAchievements, numCompleted = GetNumCompletedAchievements()
+		else
+			numAchievements, numCompleted = AchievementFrame_GetCategoryTotalNumAchievements(id, true)
 		end
-		local numAchievements, numCompleted = GetCategoryNumAchievements(id)
+
 		local statusBar = AchievementFrameComparisonSummaryPlayerStatusBar
 		PlayAnimationStatusBar(statusBar, numAchievements, numCompleted)
 
-		local friendCompleted = GetComparisonCategoryNumAchievements(id)
+		local friendCompleted = GetComparisonCategoryNumAchievements(id == "summary" and ACHIEVEMENT_COMPARISON_SUMMARY_ID or id)
 		statusBar = AchievementFrameComparisonSummaryFriendStatusBar
 		PlayAnimationStatusBar(statusBar, numAchievements, friendCompleted)
 	end)

--- a/ElvUI_Enhanced/Modules/Blizzard/AnimatedAchievementsBars.lua
+++ b/ElvUI_Enhanced/Modules/Blizzard/AnimatedAchievementsBars.lua
@@ -36,7 +36,12 @@ S:AddCallbackForAddon("Blizzard_AchievementUI", "Enhanced_AchievementUI", functi
 		bar:SetValue(0)
 		bar.anim.progress:SetChange(value)
 
-		local r, g, b = E:ColorGradient(value / max, 1, 0, 0, 1, 1, 0, 0, 1, 0)
+		local r, g, b
+		if max == 0 then
+			r, g, b = E:ColorGradient(0, 1, 0, 0, 1, 1, 0, 0, 1, 0)
+		else
+			r, g, b = E:ColorGradient(value / max, 1, 0, 0, 1, 1, 0, 0, 1, 0)
+		end
 		bar.anim.color:Reset()
 		bar.anim.color:SetChange(r, g, b)
 		bar.anim:Play()
@@ -71,6 +76,9 @@ S:AddCallbackForAddon("Blizzard_AchievementUI", "Enhanced_AchievementUI", functi
 	end)
 
 	hooksecurefunc("AchievementFrameComparison_UpdateStatusBars", function(id)
+		if id == "summary" then
+			id = -1
+		end
 		local numAchievements, numCompleted = GetCategoryNumAchievements(id)
 		local statusBar = AchievementFrameComparisonSummaryPlayerStatusBar
 		PlayAnimationStatusBar(statusBar, numAchievements, numCompleted)


### PR DESCRIPTION
Fixes Lua error when enabling Progress info. Happens randomly when hovering over people.

Error is - Blizzard_AchievementUI\Blizzard_AchievementUI.lua:568: Usage: GetCategoryNumAchievements(categoryID)

Fixes https://github.com/ElvUI-WotLK/ElvUI_Enhanced/issues/119, https://github.com/ElvUI-WotLK/ElvUI_Enhanced/issues/114, https://github.com/ElvUI-WotLK/ElvUI_Enhanced/issues/99

Also fixes lua error when enabling Animated Achievement Bars option. Comparing achievements and selecting category Feats of Strength while having no actual achievements there results in an error.